### PR TITLE
[FIX] Error on Install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ["version"]
 repository = "https://github.com/uniwuezpd/PAGETools"
 
 [project.scripts]
-pagetools = "pagetools.cli: cli"
+pagetools = "pagetools.cli:cli"
 
 [options]
 include_package_data = true


### PR DESCRIPTION
PAGETools failed to install for me when I tried using pip and when I tried cloning the repository and installing it locally until I removed this space.