### PR TITLE
Line2Page: Convert RGB argument to BGR for OpenCV

### DIFF
--- a/pagetools/src/line2page/Line2Page.py
+++ b/pagetools/src/line2page/Line2Page.py
@@ -62,7 +62,7 @@ class Line2Page:
         self.pred_suffix = ".pred.txt"
         self.img_suffix = output_extension if output_extension else ext
 
-        self.background_colour = background_color
+        self.background_colour = tuple(reversed(background_color))
         self.colour_channels = 3
         if border[1] > lines:
             footer_size = border[1] - lines


### PR DESCRIPTION
Convert `--background-color` tuple from RGB channel order to BGR order used by [OpenCV](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga8ac397bd09e48851665edbe12aa28f25).